### PR TITLE
Adds releasever and basearch filtering tests

### DIFF
--- a/vmaas/misc/packages.py
+++ b/vmaas/misc/packages.py
@@ -135,6 +135,62 @@ EXPECTED_OTHER_REPO = [
     }
 ]
 
+EXPECTED_I386_FILTER_2_2 = [
+    {
+        "basearch": "x86_64",
+        "erratum": "vmaas_test_i386_1.1",
+        "package": "test-arch-vmaas-2-2.i386",
+        "releasever": "7",
+        "repository": "vmaas-test-x86_64"
+    }
+]
+
+EXPECTED_I386_FILTER_3_3 = [
+    {
+        "basearch": "x86_64",
+        "erratum": "vmaas_test_i386_2.1",
+        "package": "test-arch-vmaas-3-3.i386",
+        "releasever": "7",
+        "repository": "vmaas-test-x86_64"
+    }
+]
+
+EXPECTED_BASEARCH_FILTER_1 = [
+    {
+        "basearch": "i386",
+        "erratum": "vmaas_test_i386_1",
+        "package": "test-arch-vmaas-",
+        "repository": "vmaas-test-i386"
+    }
+]
+
+EXPECTED_BASEARCH_FILTER_2 = [
+    {
+        "basearch": "i386",
+        "erratum": "vmaas_test_i386_2",
+        "package": "test-arch-vmaas-",
+        "repository": "vmaas-test-i386"
+    }
+]
+
+EXPECTED_RELEASE_FILTER_1 = [
+    {
+        "erratum": "vmaas_test_i386_1",
+        "package": "test-arch-vmaas-",
+        "releasever": "6",
+        "repository": "vmaas-test-i386"
+    }
+]
+
+EXPECTED_RELEASE_FILTER_2 = [
+    {
+        "erratum": "vmaas_test_i386_2",
+        "package": "test-arch-vmaas-",
+        "releasever": "6",
+        "repository": "vmaas-test-i386"
+    }
+]
+
 PACKAGES_BASIC = [
     # package, expected updates
     ('bash-0:4.2.45-5.el7_0.2.x86_64', EXPECTED_BASH),
@@ -168,4 +224,168 @@ PACKAGES_OTHER_REPO = [
     ('test-vmaas-1-1.x86_64', EXPECTED_OTHER_REPO),
     ('test-vmaas-2-2.x86_64', None),
     ('test-vmaas-3-3.x86_64', None)
+]
+
+PACKAGES_I386_W_FILTER = [
+    ('test-arch-vmaas-1-1.i386', EXPECTED_I386_FILTER_2_2 + EXPECTED_I386_FILTER_3_3),
+    ('test-arch-vmaas-2-2.i386', EXPECTED_I386_FILTER_3_3),
+    ('test-arch-vmaas-3-3.i386', None)
+]
+
+PACKAGES_BASEARCH_FILTER = [
+    ('test-arch-vmaas-1-1.i386', EXPECTED_BASEARCH_FILTER_1 + EXPECTED_BASEARCH_FILTER_2),
+    ('test-arch-vmaas-2-2.i386', EXPECTED_BASEARCH_FILTER_2),
+    ('test-arch-vmaas-3-3.i386', None)
+]
+
+PACKAGES_RELEASE_FILTER = [
+    ('test-arch-vmaas-1-1.i386', EXPECTED_RELEASE_FILTER_1 + EXPECTED_RELEASE_FILTER_2),
+    ('test-arch-vmaas-2-2.i386', EXPECTED_RELEASE_FILTER_2),
+    ('test-arch-vmaas-3-3.i386', None)
+]
+
+
+
+EXPECTED_BASH_PARTIAL = [
+    {
+        "erratum": "RHSA-2017:1931",
+        "repository": "rhel-7-server-rpms",
+        "package": "bash-"
+    },
+    {
+        "erratum": "RHSA-2017:1931",
+        "repository": "rhel-7-workstation-rpms",
+        "package": "bash-"
+    },
+]
+
+EXPECTED_BASH_W_REPO = [
+    {
+        "erratum": "RHSA-2017:1931",
+        "repository": "rhel-7-server-rpms",
+        "package": "bash-"
+    },
+]
+
+EXPECTED_POSTGRES = [
+    {
+        "erratum": "RHSA-2017:3402",
+        "repository": "rhel-7-server-rpms",
+        "package": "postgresql-"
+    },
+    {
+        "erratum": "RHSA-2017:3402",
+        "repository": "rhel-7-workstation-rpms",
+        "package": "postgresql-"
+    },
+    {
+        "erratum": "RHSA-2017:2728",
+        "repository": "rhel-7-server-rpms",
+        "package": "postgresql-"
+    },
+    {
+        "erratum": "RHSA-2017:2728",
+        "repository": "rhel-7-workstation-rpms",
+        "package": "postgresql-"
+    },
+    {
+        "erratum": "RHSA-2017:1983",
+        "repository": "rhel-7-server-rpms",
+        "package": "postgresql-"
+    },
+    {
+        "erratum": "RHSA-2017:1983",
+        "repository": "rhel-7-workstation-rpms",
+        "package": "postgresql-"
+    },
+]
+
+EXPECTED_POSTGRES_W_REPO = [
+    {
+        "erratum": "RHSA-2017:3402",
+        "repository": "rhel-7-server-rpms",
+        "package": "postgresql-"
+    },
+    {
+        "erratum": "RHSA-2017:2728",
+        "repository": "rhel-7-server-rpms",
+        "package": "postgresql-"
+    },
+    {
+        "erratum": "RHSA-2017:1983",
+        "repository": "rhel-7-server-rpms",
+        "package": "postgresql-"
+    },
+]
+
+EXPECTED_POSTGRES_DEVEL = [
+    {
+        "erratum": "RHSA-2017:1983",
+        "repository": "rhel-7-server-rpms",
+        "package": "postgresql-devel-"
+    },
+    {
+        "erratum": "RHSA-2017:1983",
+        "repository": "rhel-7-workstation-rpms",
+        "package": "postgresql-devel-"
+    },
+    {
+        "erratum": "RHSA-2017:2728",
+        "repository": "rhel-7-server-rpms",
+        "package": "postgresql-devel-"
+    },
+    {
+        "erratum": "RHSA-2017:2728",
+        "repository": "rhel-7-workstation-rpms",
+        "package": "postgresql-devel-"
+    },
+    {
+        "erratum": "RHSA-2017:3402",
+        "repository": "rhel-7-server-rpms",
+        "package": "postgresql-devel-"
+    },
+    {
+        "erratum": "RHSA-2017:3402",
+        "repository": "rhel-7-workstation-rpms",
+        "package": "postgresql-devel-"
+    }
+]
+
+EXPECTED_POSTGRES_DEVEL_W_REPO = [
+    {
+        "erratum": "RHSA-2017:1983",
+        "repository": "rhel-7-server-rpms",
+        "package": "postgresql-devel-"
+    },
+    {
+        "erratum": "RHSA-2017:2728",
+        "repository": "rhel-7-server-rpms",
+        "package": "postgresql-devel-"
+    },
+    {
+        "erratum": "RHSA-2017:3402",
+        "repository": "rhel-7-server-rpms",
+        "package": "postgresql-devel-"
+    },
+]
+
+
+PACKAGES = [
+    # package, expected updates
+    ('bash-0:4.2.46-20.el7_2.x86_64', EXPECTED_BASH_PARTIAL),
+    ('postgresql-0:9.2.18-1.el7.x86_64', EXPECTED_POSTGRES),
+    ('postgresql-devel-9.2.18-1.el7.x86_64', EXPECTED_POSTGRES_DEVEL),
+    ('telepathy-logger-0.8.0-5.el7.x86_64', None),
+]
+
+PACKAGES_W_REPOS = [
+    # package, expected updates
+    ('bash-0:4.2.46-20.el7_2.x86_64', EXPECTED_BASH_W_REPO),
+    ('postgresql-0:9.2.18-1.el7.x86_64', EXPECTED_POSTGRES_W_REPO),
+    ('postgresql-devel-9.2.18-1.el7.x86_64', EXPECTED_POSTGRES_DEVEL_W_REPO),
+]
+
+REPOS = [
+    'vmaas-test-1',
+    'rhel-7-server-rpms',
 ]

--- a/vmaas/rest/schemas.py
+++ b/vmaas/rest/schemas.py
@@ -4,6 +4,7 @@ Schemas of responses.
 """
 
 from schema import Optional, Schema
+from vmaas.utils.blockers import GH
 
 
 _cves = {
@@ -61,7 +62,11 @@ _repos = {
 _updates_top = {'update_list': {str: dict}}
 _updates_top_repolist = {'repository_list': [str], 'update_list': {str: dict}}
 _updates_top_basearch = {'basearch': str, 'update_list': {str: dict}}
-_updates_top_releasever = {'releasever': str, 'update_list': {str: dict}}
+
+if GH(241).blocks:
+    _updates_top_releasever = {'relasever': str, 'update_list': {str: dict}}
+else:
+    _updates_top_releasever = {'releasever': str, 'update_list': {str: dict}}
 
 _updates_package = {
     'available_updates': [

--- a/vmaas/rest/schemas.py
+++ b/vmaas/rest/schemas.py
@@ -60,6 +60,8 @@ _repos = {
 
 _updates_top = {'update_list': {str: dict}}
 _updates_top_repolist = {'repository_list': [str], 'update_list': {str: dict}}
+_updates_top_basearch = {'basearch': str, 'update_list': {str: dict}}
+_updates_top_releasever = {'releasever': str, 'update_list': {str: dict}}
 
 _updates_package = {
     'available_updates': [
@@ -80,4 +82,6 @@ errata_schema = Schema(_errata)
 repos_schema = Schema(_repos)
 updates_top_schema = Schema(_updates_top)
 updates_top_repolist_schema = Schema(_updates_top_repolist)
+updates_top_basearch_schema = Schema(_updates_top_basearch)
+updates_top_releasever_schema = Schema(_updates_top_releasever)
 updates_package_schema = Schema(_updates_package)

--- a/vmaas/tests/test_tier2_udpates.py
+++ b/vmaas/tests/test_tier2_udpates.py
@@ -14,7 +14,8 @@ class TestUpdatesBasic(object):
         schemas.updates_top_schema.validate(updates.raw.body)
         assert len(updates) == len(packages.PACKAGES_BASIC)
         for name, expected in packages.PACKAGES_BASIC:
-            tools.validate_package_updates(updates[name], expected, True)
+            tools.validate_package_updates(
+                updates[name], expected, exact_match=True)
 
     @pytest.mark.parametrize('package', packages.PACKAGES_BASIC, ids=[p[0] for p in packages.PACKAGES_BASIC])
     def test_post_single(self, rest_api, package):
@@ -25,7 +26,7 @@ class TestUpdatesBasic(object):
         schemas.updates_top_schema.validate(updates.raw.body)
         assert len(updates) == 1
         package, = updates
-        tools.validate_package_updates(package, expected, True)
+        tools.validate_package_updates(package, expected, exact_match=True)
 
     @pytest.mark.parametrize('package', packages.PACKAGES_BASIC, ids=[p[0] for p in packages.PACKAGES_BASIC])
     def test_get_single(self, rest_api, package):
@@ -35,17 +36,20 @@ class TestUpdatesBasic(object):
         schemas.updates_top_schema.validate(updates.raw.body)
         assert len(updates) == 1
         package, = updates
-        tools.validate_package_updates(package, expected, True)
+        tools.validate_package_updates(package, expected, exact_match=True)
+
 
 class TestUpdateInOtherRepo(object):
     def test_post_multi(self, rest_api):
         """Tests correct updates in different repo using POST with multiple packages."""
-        body = tools.gen_updates_body([p[0] for p in packages.PACKAGES_OTHER_REPO])
+        body = tools.gen_updates_body(
+            [p[0] for p in packages.PACKAGES_OTHER_REPO])
         updates = rest_api.get_updates(body=body).response_check()
         schemas.updates_top_schema.validate(updates.raw.body)
         assert len(updates) == len(packages.PACKAGES_OTHER_REPO)
         for name, expected in packages.PACKAGES_OTHER_REPO:
-            tools.validate_package_updates(updates[name], expected, True)
+            tools.validate_package_updates(
+                updates[name], expected, exact_match=True)
 
     @pytest.mark.parametrize('package', packages.PACKAGES_OTHER_REPO, ids=[p[0] for p in packages.PACKAGES_OTHER_REPO])
     def test_post_single(self, rest_api, package):
@@ -56,7 +60,7 @@ class TestUpdateInOtherRepo(object):
         schemas.updates_top_schema.validate(updates.raw.body)
         assert len(updates) == 1
         package, = updates
-        tools.validate_package_updates(package, expected, True)
+        tools.validate_package_updates(package, expected, exact_match=True)
 
     @pytest.mark.parametrize('package', packages.PACKAGES_OTHER_REPO, ids=[p[0] for p in packages.PACKAGES_OTHER_REPO])
     def test_get_single(self, rest_api, package):
@@ -66,18 +70,20 @@ class TestUpdateInOtherRepo(object):
         schemas.updates_top_schema.validate(updates.raw.body)
         assert len(updates) == 1
         package, = updates
-        tools.validate_package_updates(package, expected, True)
+        tools.validate_package_updates(package, expected, exact_match=True)
 
 
 class TestUpdateToNoarch(object):
     def test_post_multi(self, rest_api):
         """Tests correct updates to noarch package using POST with multiple packages."""
-        body = tools.gen_updates_body([p[0] for p in packages.PACKAGES_TO_NOARCH])
+        body = tools.gen_updates_body(
+            [p[0] for p in packages.PACKAGES_TO_NOARCH])
         updates = rest_api.get_updates(body=body).response_check()
         schemas.updates_top_schema.validate(updates.raw.body)
         assert len(updates) == len(packages.PACKAGES_TO_NOARCH)
         for name, expected in packages.PACKAGES_TO_NOARCH:
-            tools.validate_package_updates(updates[name], expected, True)
+            tools.validate_package_updates(updates[name], expected,
+                                           exact_match=True)
 
     @pytest.mark.parametrize('package', packages.PACKAGES_TO_NOARCH, ids=[p[0] for p in packages.PACKAGES_TO_NOARCH])
     def test_post_single(self, rest_api, package):
@@ -88,7 +94,7 @@ class TestUpdateToNoarch(object):
         schemas.updates_top_schema.validate(updates.raw.body)
         assert len(updates) == 1
         package, = updates
-        tools.validate_package_updates(package, expected, True)
+        tools.validate_package_updates(package, expected, exact_match=True)
 
     @pytest.mark.parametrize('package', packages.PACKAGES_TO_NOARCH, ids=[p[0] for p in packages.PACKAGES_TO_NOARCH])
     def test_get_single(self, rest_api, package):
@@ -98,18 +104,20 @@ class TestUpdateToNoarch(object):
         schemas.updates_top_schema.validate(updates.raw.body)
         assert len(updates) == 1
         package, = updates
-        tools.validate_package_updates(package, expected, True)
+        tools.validate_package_updates(package, expected, exact_match=True)
 
 
 class TestUpdateFromNoarch(object):
     def test_post_multi(self, rest_api):
         """Tests correct updates from noarch using POST with multiple packages."""
-        body = tools.gen_updates_body([p[0] for p in packages.PACKAGES_FROM_NOARCH])
+        body = tools.gen_updates_body(
+            [p[0] for p in packages.PACKAGES_FROM_NOARCH])
         updates = rest_api.get_updates(body=body).response_check()
         schemas.updates_top_schema.validate(updates.raw.body)
         assert len(updates) == len(packages.PACKAGES_FROM_NOARCH)
         for name, expected in packages.PACKAGES_FROM_NOARCH:
-            tools.validate_package_updates(updates[name], expected, True)
+            tools.validate_package_updates(
+                updates[name], expected, exact_match=True)
 
     @pytest.mark.parametrize('package', packages.PACKAGES_FROM_NOARCH, ids=[p[0] for p in packages.PACKAGES_FROM_NOARCH])
     def test_post_single(self, rest_api, package):
@@ -120,7 +128,7 @@ class TestUpdateFromNoarch(object):
         schemas.updates_top_schema.validate(updates.raw.body)
         assert len(updates) == 1
         package, = updates
-        tools.validate_package_updates(package, expected, True)
+        tools.validate_package_updates(package, expected, exact_match=True)
 
     @pytest.mark.parametrize('package', packages.PACKAGES_FROM_NOARCH, ids=[p[0] for p in packages.PACKAGES_FROM_NOARCH])
     def test_get_single(self, rest_api, package):
@@ -130,4 +138,33 @@ class TestUpdateFromNoarch(object):
         schemas.updates_top_schema.validate(updates.raw.body)
         assert len(updates) == 1
         package, = updates
-        tools.validate_package_updates(package, expected, True)
+        tools.validate_package_updates(package, expected, exact_match=True)
+
+
+class TestUpdateI386Filter(object):
+    def test_post_multi(self, rest_api):
+        """Tests correct updates from i386 package with basearch set to x86_64
+        using POST with multiple packages.
+        """
+        body = tools.gen_updates_body(
+            [p[0] for p in packages.PACKAGES_I386_W_FILTER], basearch='x86_64')
+        updates = rest_api.get_updates(body=body).response_check()
+        # from IPython import embed; embed()
+        schemas.updates_top_basearch_schema.validate(updates.raw.body)
+        assert len(updates) == len(packages.PACKAGES_I386_W_FILTER)
+        for name, expected in packages.PACKAGES_I386_W_FILTER:
+            tools.validate_package_updates(
+                updates[name], expected, exact_match=True)
+
+    @pytest.mark.parametrize('package', packages.PACKAGES_I386_W_FILTER, ids=[p[0] for p in packages.PACKAGES_I386_W_FILTER])
+    def test_post_single(self, rest_api, package):
+        """Tests correct updates from i386 package with basearch set to x86_64
+        using POST with single package.
+        """
+        name, expected = package
+        body = tools.gen_updates_body([name], basearch='x86_64')
+        updates = rest_api.get_updates(body=body).response_check()
+        schemas.updates_top_basearch_schema.validate(updates.raw.body)
+        assert len(updates) == 1
+        package, = updates
+        tools.validate_package_updates(package, expected, exact_match=True)

--- a/vmaas/tests/test_updates.py
+++ b/vmaas/tests/test_updates.py
@@ -3,165 +3,21 @@
 import pytest
 
 from vmaas.rest import schemas, tools
-
-
-EXPECTED_BASH = [
-    {
-        "erratum": "RHSA-2017:1931",
-        "repository": "rhel-7-server-rpms",
-        "package": "bash-"
-    },
-    {
-        "erratum": "RHSA-2017:1931",
-        "repository": "rhel-7-workstation-rpms",
-        "package": "bash-"
-    },
-]
-
-EXPECTED_BASH_W_REPO = [
-    {
-        "erratum": "RHSA-2017:1931",
-        "repository": "rhel-7-server-rpms",
-        "package": "bash-"
-    },
-]
-
-EXPECTED_POSTGRES = [
-    {
-        "erratum": "RHSA-2017:3402",
-        "repository": "rhel-7-server-rpms",
-        "package": "postgresql-"
-    },
-    {
-        "erratum": "RHSA-2017:3402",
-        "repository": "rhel-7-workstation-rpms",
-        "package": "postgresql-"
-    },
-    {
-        "erratum": "RHSA-2017:2728",
-        "repository": "rhel-7-server-rpms",
-        "package": "postgresql-"
-    },
-    {
-        "erratum": "RHSA-2017:2728",
-        "repository": "rhel-7-workstation-rpms",
-        "package": "postgresql-"
-    },
-    {
-        "erratum": "RHSA-2017:1983",
-        "repository": "rhel-7-server-rpms",
-        "package": "postgresql-"
-    },
-    {
-        "erratum": "RHSA-2017:1983",
-        "repository": "rhel-7-workstation-rpms",
-        "package": "postgresql-"
-    },
-]
-
-EXPECTED_POSTGRES_W_REPO = [
-    {
-        "erratum": "RHSA-2017:3402",
-        "repository": "rhel-7-server-rpms",
-        "package": "postgresql-"
-    },
-    {
-        "erratum": "RHSA-2017:2728",
-        "repository": "rhel-7-server-rpms",
-        "package": "postgresql-"
-    },
-    {
-        "erratum": "RHSA-2017:1983",
-        "repository": "rhel-7-server-rpms",
-        "package": "postgresql-"
-    },
-]
-
-EXPECTED_POSTGRES_DEVEL = [
-    {
-        "erratum": "RHSA-2017:1983",
-        "repository": "rhel-7-server-rpms",
-        "package": "postgresql-devel-"
-    },
-    {
-        "erratum": "RHSA-2017:1983",
-        "repository": "rhel-7-workstation-rpms",
-        "package": "postgresql-devel-"
-    },
-    {
-        "erratum": "RHSA-2017:2728",
-        "repository": "rhel-7-server-rpms",
-        "package": "postgresql-devel-"
-    },
-    {
-        "erratum": "RHSA-2017:2728",
-        "repository": "rhel-7-workstation-rpms",
-        "package": "postgresql-devel-"
-    },
-    {
-        "erratum": "RHSA-2017:3402",
-        "repository": "rhel-7-server-rpms",
-        "package": "postgresql-devel-"
-    },
-    {
-        "erratum": "RHSA-2017:3402",
-        "repository": "rhel-7-workstation-rpms",
-        "package": "postgresql-devel-"
-    }
-]
-
-EXPECTED_POSTGRES_DEVEL_W_REPO = [
-    {
-        "erratum": "RHSA-2017:1983",
-        "repository": "rhel-7-server-rpms",
-        "package": "postgresql-devel-"
-    },
-    {
-        "erratum": "RHSA-2017:2728",
-        "repository": "rhel-7-server-rpms",
-        "package": "postgresql-devel-"
-    },
-    {
-        "erratum": "RHSA-2017:3402",
-        "repository": "rhel-7-server-rpms",
-        "package": "postgresql-devel-"
-    },
-]
-
-
-PACKAGES = [
-    # package, expected updates
-    ('bash-0:4.2.46-20.el7_2.x86_64', EXPECTED_BASH),
-    ('postgresql-0:9.2.18-1.el7.x86_64', EXPECTED_POSTGRES),
-    ('postgresql-devel-9.2.18-1.el7.x86_64', EXPECTED_POSTGRES_DEVEL),
-    ('telepathy-logger-0.8.0-5.el7.x86_64', None),
-]
-
-PACKAGES_W_REPOS = [
-    # package, expected updates
-    ('bash-0:4.2.46-20.el7_2.x86_64', EXPECTED_BASH_W_REPO),
-    ('postgresql-0:9.2.18-1.el7.x86_64', EXPECTED_POSTGRES_W_REPO),
-    ('postgresql-devel-9.2.18-1.el7.x86_64', EXPECTED_POSTGRES_DEVEL_W_REPO),
-]
-
-REPOS = [
-    'vmaas-test-1',
-    'rhel-7-server-rpms',
-]
+from vmaas.misc import packages
 
 
 class TestUpdatesAll(object):
     def test_post_multi(self, rest_api):
         """Tests updates using POST with multiple packages."""
-        request_body = tools.gen_updates_body([p[0] for p in PACKAGES])
+        request_body = tools.gen_updates_body([p[0] for p in packages.PACKAGES])
         updates = rest_api.get_updates(body=request_body).response_check()
         schemas.updates_top_schema.validate(updates.raw.body)
-        assert len(updates) == len(PACKAGES)
-        for package_name, expected_updates in PACKAGES:
+        assert len(updates) == len(packages.PACKAGES)
+        for package_name, expected_updates in packages.PACKAGES:
             package = updates[package_name]
             tools.validate_package_updates(package, expected_updates)
 
-    @pytest.mark.parametrize('package_record', PACKAGES, ids=[p[0] for p in PACKAGES])
+    @pytest.mark.parametrize('package_record', packages.PACKAGES, ids=[p[0] for p in packages.PACKAGES])
     def test_post_single(self, rest_api, package_record):
         """Tests updates using POST with single package."""
         name, expected_updates = package_record
@@ -172,7 +28,7 @@ class TestUpdatesAll(object):
         package, = updates
         tools.validate_package_updates(package, expected_updates)
 
-    @pytest.mark.parametrize('package_record', PACKAGES, ids=[p[0] for p in PACKAGES])
+    @pytest.mark.parametrize('package_record', packages.PACKAGES, ids=[p[0] for p in packages.PACKAGES])
     def test_get(self, rest_api, package_record):
         """Tests updates using GET with single package."""
         name, expected_updates = package_record
@@ -186,22 +42,74 @@ class TestUpdatesAll(object):
 class TestUpdatesInRepos(object):
     def test_post_multi(self, rest_api):
         """Tests updates in repos using POST with multiple packages."""
-        request_body = tools.gen_updates_body([p[0] for p in PACKAGES_W_REPOS], repositories=REPOS)
+        request_body = tools.gen_updates_body([p[0] for p in packages.PACKAGES_W_REPOS], repositories=packages.REPOS)
         updates = rest_api.get_updates(body=request_body).response_check()
         schemas.updates_top_repolist_schema.validate(updates.raw.body)
-        assert len(updates) == len(PACKAGES_W_REPOS)
-        for package_name, expected_updates in PACKAGES_W_REPOS:
+        assert len(updates) == len(packages.PACKAGES_W_REPOS)
+        for package_name, expected_updates in packages.PACKAGES_W_REPOS:
             package = updates[package_name]
             tools.validate_package_updates(package, expected_updates)
 
     @pytest.mark.parametrize(
-        'package_record', PACKAGES_W_REPOS, ids=[p[0] for p in PACKAGES_W_REPOS])
+        'package_record', packages.PACKAGES_W_REPOS, ids=[p[0] for p in packages.PACKAGES_W_REPOS])
     def test_post_single(self, rest_api, package_record):
         """Tests updates in repos using POST with single package."""
         name, expected_updates = package_record
-        request_body = tools.gen_updates_body([name], repositories=REPOS)
+        request_body = tools.gen_updates_body([name], repositories=packages.REPOS)
         updates = rest_api.get_updates(body=request_body).response_check()
         schemas.updates_top_repolist_schema.validate(updates.raw.body)
+        assert len(updates) == 1
+        package, = updates
+        tools.validate_package_updates(package, expected_updates)
+
+
+class TestUpdatesFilterRelease(object):
+    """docstring for TestUpdatesFilterRelease"""
+    def test_post_multi(self, rest_api):
+        """Tests updates with filtered release version using POST with multiple packages."""
+        request_body = tools.gen_updates_body(
+            [p[0] for p in packages.PACKAGES_RELEASE_FILTER], releasever='6')
+        updates = rest_api.get_updates(body=request_body).response_check()
+        schemas.updates_top_releasever_schema.validate(updates.raw.body)
+        assert len(updates) == len(packages.PACKAGES_RELEASE_FILTER)
+        for package_name, expected_updates in packages.PACKAGES_RELEASE_FILTER:
+            package = updates[package_name]
+            tools.validate_package_updates(package, expected_updates)
+
+    @pytest.mark.parametrize(
+        'package_record', packages.PACKAGES_RELEASE_FILTER, ids=[p[0] for p in packages.PACKAGES_RELEASE_FILTER])
+    def test_post_single(self, rest_api, package_record):
+        """Tests updates with filtered release version using POST with single package."""
+        name, expected_updates = package_record
+        request_body = tools.gen_updates_body([name], releasever='6')
+        updates = rest_api.get_updates(body=request_body).response_check()
+        schemas.updates_top_releasever_schema.validate(updates.raw.body)
+        assert len(updates) == 1
+        package, = updates
+        tools.validate_package_updates(package, expected_updates)
+
+
+class TestUpdatesFilterBasearch(object):
+    """docstring for TestUpdatesFilterBasearch"""
+    def test_post_multi(self, rest_api):
+        """Tests updates with filtered basearch using POST with multiple packages."""
+        request_body = tools.gen_updates_body(
+            [p[0] for p in packages.PACKAGES_BASEARCH_FILTER], basearch='i386')
+        updates = rest_api.get_updates(body=request_body).response_check()
+        schemas.updates_top_basearch_schema.validate(updates.raw.body)
+        assert len(updates) == len(packages.PACKAGES_BASEARCH_FILTER)
+        for package_name, expected_updates in packages.PACKAGES_BASEARCH_FILTER:
+            package = updates[package_name]
+            tools.validate_package_updates(package, expected_updates)
+
+    @pytest.mark.parametrize(
+        'package_record', packages.PACKAGES_BASEARCH_FILTER, ids=[p[0] for p in packages.PACKAGES_BASEARCH_FILTER])
+    def test_post_single(self, rest_api, package_record):
+        """Tests updates with filtered basearch using POST with single package."""
+        name, expected_updates = package_record
+        request_body = tools.gen_updates_body([name], basearch='i386')
+        updates = rest_api.get_updates(body=request_body).response_check()
+        schemas.updates_top_basearch_schema.validate(updates.raw.body)
         assert len(updates) == 1
         package, = updates
         tools.validate_package_updates(package, expected_updates)


### PR DESCRIPTION
- simple basearch and releasever filtering in `test_updates.py`
- test correct updates for i386 package with basearch set to x86_64
- expected packages moved to `misc/packages.py`
- updated schema for releasever and basearch, with workaround for https://github.com/RedHatInsights/vmaas/issues/241
- modified data validation