### PR TITLE
Don't merge yet - Rename env.yaml to env.yaml.template

### DIFF
--- a/conf/env.yaml.template
+++ b/conf/env.yaml.template
@@ -1,3 +1,4 @@
 hostname: 127.0.0.1
 github:
     upstream_repo: RedHatInsights/vmaas
+#   token: <optional-github-token>


### PR DESCRIPTION
Users now need to either copy the template to env.yaml and set it up or get the config elsewhere (e.g. internal repo)

At the same time I'm updating the internal repo and adding a GH token to it. Our CI creates a symlink before running; I would suggest doing the same to you guys. @mkoura @psegedy 