### PR TITLE
Workaround for DB sync - export

### DIFF
--- a/vmaas/scripts/setup_db.sh
+++ b/vmaas/scripts/setup_db.sh
@@ -56,4 +56,9 @@ curl -X GET "http://$2:8081/api/v1/sync/cve"
 printf "\n"
 sleep_or_wait "CVE sync task finished: OK" 120 $3
 
+printf "WORKAROUND GH#271: "
+curl -X GET "http://$2:8081/api/v1/sync/export"
+printf "\n"
+sleep_or_wait "WORKAROUND export task finished: OK" 120 $3
+
 printf "Done.\n"


### PR DESCRIPTION
Application is now using dumps instead of getting data directly from DB.

- `/sync/export` API is called only with `/sync` and not with `/sync/repo` or `/sync/cve`
- we have to use `\sync\repo`, because with `\sync` it is not possible to sync new repositories