### PR TITLE
Extend tests

### DIFF
--- a/vmaas/misc/packages.py
+++ b/vmaas/misc/packages.py
@@ -375,13 +375,15 @@ PACKAGES = [
     ('postgresql-0:9.2.18-1.el7.x86_64', EXPECTED_POSTGRES),
     ('postgresql-devel-9.2.18-1.el7.x86_64', EXPECTED_POSTGRES_DEVEL),
     ('telepathy-logger-0.8.0-5.el7.x86_64', None),
+    ('vim-common-2:7.4.160-1.el7.x86_64.rpm', EXPECTED_VIM),
+    ('non-exist-0:1.1-1.el7.x86_64', None)
 ]
 
 PACKAGES_W_REPOS = [
     # package, expected updates
     ('bash-0:4.2.46-20.el7_2.x86_64', EXPECTED_BASH_W_REPO),
     ('postgresql-0:9.2.18-1.el7.x86_64', EXPECTED_POSTGRES_W_REPO),
-    ('postgresql-devel-9.2.18-1.el7.x86_64', EXPECTED_POSTGRES_DEVEL_W_REPO),
+    ('postgresql-devel-9.2.18-1.el7.x86_64', EXPECTED_POSTGRES_DEVEL_W_REPO)
 ]
 
 REPOS = [

--- a/vmaas/misc/packages.py
+++ b/vmaas/misc/packages.py
@@ -390,3 +390,5 @@ REPOS = [
     'vmaas-test-1',
     'rhel-7-server-rpms',
 ]
+
+CACHED_PKG = 'bash-0:4.2.46-20.el7_2.x86_64'

--- a/vmaas/rest/tools.py
+++ b/vmaas/rest/tools.py
@@ -6,6 +6,8 @@ REST API helper functions
 import datetime
 
 from vmaas.rest import schemas
+from vmaas.rest.client import VMaaSClient
+from vmaas.utils.conf import conf
 
 
 def gen_cves_body(cves, modified_since=None):
@@ -183,3 +185,12 @@ def validate_cves(cve, expected):
 
     # check that expected data are present in the response
     cve_match(expected[0], cve)
+
+
+def rest_api():
+    hostname = conf.get('hostname', 'localhost')
+    try:
+        hostname, port = hostname.split(':')
+    except ValueError:
+        port = 8080 if hostname in ('localhost', '127.0.0.1') else 80
+    return VMaaSClient(hostname, port=port)

--- a/vmaas/tests/conftest.py
+++ b/vmaas/tests/conftest.py
@@ -4,6 +4,7 @@ import logging
 
 import pytest
 
+from vmaas.misc import packages
 from vmaas.rest import tools
 
 
@@ -21,19 +22,24 @@ def rest_api():
 
 @pytest.fixture(scope="session", autouse=True)
 def cache_bash():
-    """
-    Each process of webapp has its own cache. Cache responses for bash
-    package update request, with and without filters.
+    """Cache responses for bash package update request, with and without filters.
+
+
+    It *have to be run at the beginning of test suite* to cache response w/
+    filters to one process and response w/o filters to the other one.
+    Each process of webapp has its own cache.
+    Application will cache response from tests otherwise and there could be
+    same cached response if we don't run this first.
+
     Helps to catch https://github.com/RedHatInsights/vmaas/issues/306
     """
 
     rest_api = tools.rest_api()
     # cache response for plain bash updates
-    request_body = tools.gen_updates_body(
-        ['bash-0:4.2.46-20.el7_2.x86_64'])
+    request_body = tools.gen_updates_body([packages.CACHED_PKG])
     rest_api.get_updates(body=request_body).response_check()
     # cache reponse for bash updates with filter
     rest_api = tools.rest_api()
     request_body = tools.gen_updates_body(
-        ['bash-0:4.2.46-20.el7_2.x86_64'], releasever='7Server')
+        [packages.CACHED_PKG], releasever='7Server')
     rest_api.get_updates(body=request_body).response_check()

--- a/vmaas/tests/conftest.py
+++ b/vmaas/tests/conftest.py
@@ -5,8 +5,6 @@ import logging
 import pytest
 
 from vmaas.rest import tools
-from vmaas.rest.client import VMaaSClient
-from vmaas.utils.conf import conf
 
 
 logging.basicConfig()
@@ -16,22 +14,9 @@ def pytest_configure(config):
     config.addinivalue_line('markers', 'smoke: mark a test as a smoke test.')
 
 
-@pytest.fixture(name='make_conn')
-def _make_conn():
-    def make_conn():
-        hostname = conf.get('hostname', 'localhost')
-        try:
-            hostname, port = hostname.split(':')
-        except ValueError:
-            port = 8080 if hostname in ('localhost', '127.0.0.1') else 80
-        return VMaaSClient(hostname, port=port)
-
-    yield make_conn
-
-
 @pytest.fixture()
-def rest_api(make_conn):
-    return make_conn()
+def rest_api():
+    return tools.rest_api()
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -42,19 +27,13 @@ def cache_bash():
     Helps to catch https://github.com/RedHatInsights/vmaas/issues/306
     """
 
-    hostname = conf.get('hostname', 'localhost')
-    try:
-        hostname, port = hostname.split(':')
-    except ValueError:
-        port = 8080 if hostname in ('localhost', '127.0.0.1') else 80
-    rest_api = VMaaSClient(hostname, port=port)
-
+    rest_api = tools.rest_api()
     # cache response for plain bash updates
     request_body = tools.gen_updates_body(
         ['bash-0:4.2.46-20.el7_2.x86_64'])
     rest_api.get_updates(body=request_body).response_check()
     # cache reponse for bash updates with filter
-    rest_api = VMaaSClient(hostname, port=port)
+    rest_api = tools.rest_api()
     request_body = tools.gen_updates_body(
         ['bash-0:4.2.46-20.el7_2.x86_64'], releasever='7Server')
     rest_api.get_updates(body=request_body).response_check()

--- a/vmaas/tests/conftest.py
+++ b/vmaas/tests/conftest.py
@@ -4,6 +4,7 @@ import logging
 
 import pytest
 
+from vmaas.rest import tools
 from vmaas.rest.client import VMaaSClient
 from vmaas.utils.conf import conf
 
@@ -15,11 +16,45 @@ def pytest_configure(config):
     config.addinivalue_line('markers', 'smoke: mark a test as a smoke test.')
 
 
+@pytest.fixture(name='make_conn')
+def _make_conn():
+    def make_conn():
+        hostname = conf.get('hostname', 'localhost')
+        try:
+            hostname, port = hostname.split(':')
+        except ValueError:
+            port = 8080 if hostname in ('localhost', '127.0.0.1') else 80
+        return VMaaSClient(hostname, port=port)
+
+    yield make_conn
+
+
 @pytest.fixture()
-def rest_api():
+def rest_api(make_conn):
+    return make_conn()
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cache_bash():
+    """
+    Each process of webapp has its own cache. Cache responses for bash
+    package update request, with and without filters.
+    Helps to catch https://github.com/RedHatInsights/vmaas/issues/306
+    """
+
     hostname = conf.get('hostname', 'localhost')
     try:
         hostname, port = hostname.split(':')
     except ValueError:
         port = 8080 if hostname in ('localhost', '127.0.0.1') else 80
-    return VMaaSClient(hostname, port=port)
+    rest_api = VMaaSClient(hostname, port=port)
+
+    # cache response for plain bash updates
+    request_body = tools.gen_updates_body(
+        ['bash-0:4.2.46-20.el7_2.x86_64'])
+    rest_api.get_updates(body=request_body).response_check()
+    # cache reponse for bash updates with filter
+    rest_api = VMaaSClient(hostname, port=port)
+    request_body = tools.gen_updates_body(
+        ['bash-0:4.2.46-20.el7_2.x86_64'], releasever='7Server')
+    rest_api.get_updates(body=request_body).response_check()

--- a/vmaas/tests/test_updates.py
+++ b/vmaas/tests/test_updates.py
@@ -11,7 +11,8 @@ from vmaas.utils.blockers import GH
 class TestUpdatesAll(object):
     def test_post_multi(self, rest_api):
         """Tests updates using POST with multiple packages."""
-        request_body = tools.gen_updates_body([p[0] for p in packages.PACKAGES])
+        request_body = tools.gen_updates_body(
+            [p[0] for p in packages.PACKAGES])
         updates = rest_api.get_updates(body=request_body).response_check()
         schemas.updates_top_schema.validate(updates.raw.body)
         assert len(updates) == len(packages.PACKAGES)
@@ -64,7 +65,8 @@ class TestUpdatesInRepos(object):
     def test_post_single(self, rest_api, package_record):
         """Tests updates in repos using POST with single package."""
         name, expected_updates = package_record
-        request_body = tools.gen_updates_body([name], repositories=packages.REPOS)
+        request_body = tools.gen_updates_body(
+            [name], repositories=packages.REPOS)
         updates = rest_api.get_updates(body=request_body).response_check()
         schemas.updates_top_repolist_schema.validate(updates.raw.body)
         assert len(updates) == 1
@@ -77,7 +79,8 @@ class TestUpdatesInRepos(object):
     def test_post_nonexistent_repo(self, rest_api):
         """Tests updates in repos using POST with single package."""
         name = packages.PACKAGES_W_REPOS[0][0]
-        request_body = tools.gen_updates_body([name], repositories=['nonexistent-1'])
+        request_body = tools.gen_updates_body(
+            [name], repositories=['nonexistent-1'])
         updates = rest_api.get_updates(body=request_body).response_check()
         assert not updates
 
@@ -87,7 +90,7 @@ class TestUpdatesFilterRelease(object):
     def test_post_multi(self, rest_api):
         """Tests updates with filtered release version using POST with multiple packages."""
         request_body = tools.gen_updates_body(
-            [p[0] for p in packages.PACKAGES_RELEASE_FILTER], releasever='7')
+            [p[0] for p in packages.PACKAGES_RELEASE_FILTER], releasever='6')
         updates = rest_api.get_updates(body=request_body).response_check()
         schemas.updates_top_releasever_schema.validate(updates.raw.body)
         assert len(updates) == len(packages.PACKAGES_RELEASE_FILTER)
@@ -105,7 +108,7 @@ class TestUpdatesFilterRelease(object):
     def test_post_single(self, rest_api, package_record):
         """Tests updates with filtered release version using POST with single package."""
         name, expected_updates = package_record
-        request_body = tools.gen_updates_body([name], releasever='7')
+        request_body = tools.gen_updates_body([name], releasever='6')
         updates = rest_api.get_updates(body=request_body).response_check()
         schemas.updates_top_releasever_schema.validate(updates.raw.body)
         assert len(updates) == 1
@@ -146,3 +149,26 @@ class TestUpdatesFilterBasearch(object):
         tools.validate_package_updates(package, expected_updates)
         for update in package.available_updates:
             assert update['basearch'] == request_body['basearch']
+
+
+class TestUpdatesDiff(object):
+    def test_post_diff(self, make_conn):
+        """Tests that application returns always the same response using POST."""
+        request_body = tools.gen_updates_body(
+            ['bash-0:4.2.46-20.el7_2.x86_64'])
+        rest_api = make_conn()
+        init = rest_api.get_updates(body=request_body).response_check()
+        for i in range(100):
+            rest_api = make_conn()
+            response = rest_api.get_updates(body=request_body).response_check()
+            assert init.raw.body == response.raw.body
+
+    def test_get_diff(self, make_conn):
+        """Tests that application returns always the same response using GET."""
+        pkg = 'bash-0:4.2.46-20.el7_2.x86_64'
+        rest_api = make_conn()
+        init = rest_api.get_update(pkg).response_check()
+        for i in range(100):
+            rest_api = make_conn()
+            response = rest_api.get_update(pkg).response_check()
+            assert init.raw.body == response.raw.body

--- a/vmaas/tests/test_updates.py
+++ b/vmaas/tests/test_updates.py
@@ -155,7 +155,7 @@ class TestUpdatesDiff(object):
     def test_post_diff(self):
         """Tests that application returns always the same response using POST."""
         request_body = tools.gen_updates_body(
-            ['bash-0:4.2.46-20.el7_2.x86_64'])
+            [packages.CACHED_PKG])
         rest_api = tools.rest_api()
         init = rest_api.get_updates(body=request_body).response_check()
         for i in range(100):
@@ -165,7 +165,7 @@ class TestUpdatesDiff(object):
 
     def test_get_diff(self):
         """Tests that application returns always the same response using GET."""
-        pkg = 'bash-0:4.2.46-20.el7_2.x86_64'
+        pkg = packages.CACHED_PKG
         rest_api = tools.rest_api()
         init = rest_api.get_update(pkg).response_check()
         for i in range(100):

--- a/vmaas/tests/test_updates.py
+++ b/vmaas/tests/test_updates.py
@@ -152,23 +152,23 @@ class TestUpdatesFilterBasearch(object):
 
 
 class TestUpdatesDiff(object):
-    def test_post_diff(self, make_conn):
+    def test_post_diff(self):
         """Tests that application returns always the same response using POST."""
         request_body = tools.gen_updates_body(
             ['bash-0:4.2.46-20.el7_2.x86_64'])
-        rest_api = make_conn()
+        rest_api = tools.rest_api()
         init = rest_api.get_updates(body=request_body).response_check()
         for i in range(100):
-            rest_api = make_conn()
+            rest_api = tools.rest_api()
             response = rest_api.get_updates(body=request_body).response_check()
             assert init.raw.body == response.raw.body
 
-    def test_get_diff(self, make_conn):
+    def test_get_diff(self):
         """Tests that application returns always the same response using GET."""
         pkg = 'bash-0:4.2.46-20.el7_2.x86_64'
-        rest_api = make_conn()
+        rest_api = tools.rest_api()
         init = rest_api.get_update(pkg).response_check()
         for i in range(100):
-            rest_api = make_conn()
+            rest_api = tools.rest_api()
             response = rest_api.get_update(pkg).response_check()
             assert init.raw.body == response.raw.body

--- a/vmaas/tests/test_updates.py
+++ b/vmaas/tests/test_updates.py
@@ -56,6 +56,8 @@ class TestUpdatesInRepos(object):
         for package_name, expected_updates in packages.PACKAGES_W_REPOS:
             package = updates[package_name]
             tools.validate_package_updates(package, expected_updates)
+            for update in package.available_updates:
+                assert update['repository'] in packages.REPOS
 
     @pytest.mark.parametrize(
         'package_record', packages.PACKAGES_W_REPOS, ids=[p[0] for p in packages.PACKAGES_W_REPOS])
@@ -68,6 +70,8 @@ class TestUpdatesInRepos(object):
         assert len(updates) == 1
         package, = updates
         tools.validate_package_updates(package, expected_updates)
+        for update in package.available_updates:
+            assert update['repository'] in packages.REPOS
 
     @pytest.mark.skipif(GH(299).blocks, reason='Blocked by GH 299')
     def test_post_nonexistent_repo(self, rest_api):
@@ -83,13 +87,15 @@ class TestUpdatesFilterRelease(object):
     def test_post_multi(self, rest_api):
         """Tests updates with filtered release version using POST with multiple packages."""
         request_body = tools.gen_updates_body(
-            [p[0] for p in packages.PACKAGES_RELEASE_FILTER], releasever='6')
+            [p[0] for p in packages.PACKAGES_RELEASE_FILTER], releasever='7')
         updates = rest_api.get_updates(body=request_body).response_check()
         schemas.updates_top_releasever_schema.validate(updates.raw.body)
         assert len(updates) == len(packages.PACKAGES_RELEASE_FILTER)
         for package_name, expected_updates in packages.PACKAGES_RELEASE_FILTER:
             package = updates[package_name]
             tools.validate_package_updates(package, expected_updates)
+            for update in package.available_updates:
+                assert update['releasever'] == request_body['releasever']
 
     @pytest.mark.parametrize(
         'package_record',
@@ -99,12 +105,14 @@ class TestUpdatesFilterRelease(object):
     def test_post_single(self, rest_api, package_record):
         """Tests updates with filtered release version using POST with single package."""
         name, expected_updates = package_record
-        request_body = tools.gen_updates_body([name], releasever='6')
+        request_body = tools.gen_updates_body([name], releasever='7')
         updates = rest_api.get_updates(body=request_body).response_check()
         schemas.updates_top_releasever_schema.validate(updates.raw.body)
         assert len(updates) == 1
         package, = updates
         tools.validate_package_updates(package, expected_updates)
+        for update in package.available_updates:
+            assert update['releasever'] == request_body['releasever']
 
 
 @pytest.mark.skipif(GH(301).blocks, reason='Blocked by GH 301')
@@ -119,6 +127,8 @@ class TestUpdatesFilterBasearch(object):
         for package_name, expected_updates in packages.PACKAGES_BASEARCH_FILTER:
             package = updates[package_name]
             tools.validate_package_updates(package, expected_updates)
+            for update in package.available_updates:
+                assert update['basearch'] == request_body['basearch']
 
     @pytest.mark.parametrize(
         'package_record',
@@ -134,3 +144,5 @@ class TestUpdatesFilterBasearch(object):
         assert len(updates) == 1
         package, = updates
         tools.validate_package_updates(package, expected_updates)
+        for update in package.available_updates:
+            assert update['basearch'] == request_body['basearch']


### PR DESCRIPTION
- updates for non-existent package and pkg with `.rpm` suffix
- check that only updates with correct repo/release/basearch are returned when filter is applied
- test for https://github.com/RedHatInsights/vmaas/issues/306 - diff 100 responses -they have to be same, `cache_bash` fixture helps hit this issue
- `rest_api` fixture as `make_conn` factory, so we can send each request as a new connection (needed for above)