### PR TITLE
Regex request in errata tests

### DIFF
--- a/vmaas/tests/test_cves.py
+++ b/vmaas/tests/test_cves.py
@@ -116,7 +116,7 @@ class TestCVEsModifiedSince(object):
     def test_post_multi(self, rest_api):
         """Tests multiple CVEs using POST."""
         request_body = tools.gen_cves_body(
-            [c[0] for c in CVES], modified_since='2018-01-01')
+            [c[0] for c in CVES], modified_since='2018-01-01T00:00:00+01:00')
         cves = rest_api.get_cves(body=request_body).response_check()
         schemas.cves_schema.validate(cves.raw.body)
         assert len(cves) == len([c[1] for c in CVES if c[1]])
@@ -129,7 +129,7 @@ class TestCVEsModifiedSince(object):
         """Tests single CVE using POST."""
         cve_name, expected_name, _ = cve_in
         request_body = tools.gen_cves_body(
-            [cve_name], modified_since='2018-01-01')
+            [cve_name], modified_since='2018-01-01T00:00:00+01:00')
         cves = rest_api.get_cves(body=request_body).response_check()
         # don't validate schema on empty response
         if expected_name:

--- a/vmaas/tests/test_errata.py
+++ b/vmaas/tests/test_errata.py
@@ -85,12 +85,11 @@ class TestErrataQuery(object):
         assert erratum.name == erratum_name
 
 
-@pytest.mark.skipif(GH(299).blocks, reason='Blocked by GH 299')
 class TestErrataModifiedSince(object):
     def post_multi(self, rest_api, errata):
         """Tests multiple errata using POST."""
         request_body = tools.gen_errata_body(
-            [e[0] for e in errata], modified_since='2018-04-06')
+            [e[0] for e in errata], modified_since='2018-04-06T00:00:00+01:00')
         errata_response = rest_api.get_errata(
             body=request_body).response_check()
         schemas.errata_schema.validate(errata_response.raw.body)
@@ -103,7 +102,7 @@ class TestErrataModifiedSince(object):
         """Tests single erratum using POST."""
         name, expected_name = erratum
         request_body = tools.gen_errata_body(
-            [name], modified_since='2018-04-06')
+            [name], modified_since='2018-04-06T00:00:00+01:00')
         errata = rest_api.get_errata(body=request_body).response_check()
         # don't validate schema on empty response
         if expected_name:


### PR DESCRIPTION
- Test errata with regex matching, blocked by https://github.com/RedHatInsights/vmaas/issues/310
- https://github.com/RedHatInsights/vmaas/issues/299 is fixed, requires date with timezone https://github.com/RedHatInsights/vmaas/commit/aa42c6f29056d0dda9de649d9477dc28efb69b71