### PR TITLE
Enhance JSON testing

### DIFF
--- a/vmaas/tests/test_json.py
+++ b/vmaas/tests/test_json.py
@@ -55,10 +55,19 @@ class TestJSON(object):
         """Tests various json - /updates endpoint."""
         if json[1] == 'updates':
             updates = rest_api.get_updates(body=json[0]).response_check()
-            assert 'available_updates' not in updates.raw.body
+            assert isinstance(updates.raw.body, dict)
+            assert 'available_updates' in updates[0]
+        elif not json[1]:
+            updates = rest_api.get_updates(body=json[0]).response_check(400)
+            assert not isinstance(updates.raw.body, dict)
+            if json[0]:
+                assert "is not of type 'object'" in updates.raw.body
+            else:
+                assert 'Error: malformed input JSON' in updates.raw.body
         else:
             updates = rest_api.get_updates(body=json[0]).response_check(400)
-            assert 'available_updates' not in updates.raw.body
+            assert not isinstance(updates.raw.body, dict)
+            assert "'package_list' is a required property" in updates.raw.body
 
     @pytest.mark.skipif(GH(330).blocks or GH(329).blocks,
                         reason="blocked by GH#329 or GH#330")
@@ -67,10 +76,19 @@ class TestJSON(object):
         """Tests various json - /cves endpoint."""
         if json[1] == 'cves':
             cves = rest_api.get_cves(body=json[0]).response_check()
+            assert isinstance(cves.raw.body, dict)
             assert 'cve_list' in cves.raw.body
+        elif not json[1]:
+            cves = rest_api.get_cves(body=json[0]).response_check(400)
+            assert not isinstance(cves.raw.body, dict)
+            if json[0]:
+                assert "is not of type 'object'" in cves.raw.body
+            else:
+                assert 'Error: malformed input JSON' in cves.raw.body
         else:
             cves = rest_api.get_cves(body=json[0]).response_check(400)
-            assert 'cve_list' not in cves.raw.body
+            assert not isinstance(cves.raw.body, dict)
+            assert "'cve_list' is a required property" in cves.raw.body
 
     @pytest.mark.skipif(GH(330).blocks or GH(329).blocks,
                         reason="blocked by GH#329 or GH#330")
@@ -79,19 +97,37 @@ class TestJSON(object):
         """Tests various json - /errata endpoint."""
         if json[1] == 'errata':
             errata = rest_api.get_errata(body=json[0]).response_check()
+            assert isinstance(errata.raw.body, dict)
             assert 'errata_list' in errata.raw.body
+        elif not json[1]:
+            errata = rest_api.get_errata(body=json[0]).response_check(400)
+            assert not isinstance(errata.raw.body, dict)
+            if json[0]:
+                assert "is not of type 'object'" in errata.raw.body
+            else:
+                assert 'Error: malformed input JSON' in errata.raw.body
         else:
             errata = rest_api.get_errata(body=json[0]).response_check(400)
-            assert 'errata_list' not in errata.raw.body
+            assert not isinstance(errata.raw.body, dict)
+            assert "'errata_list' is a required property" in errata.raw.body
 
     @pytest.mark.skipif(GH(330).blocks or GH(329).blocks,
                         reason="blocked by GH#329 or GH#330")
     @pytest.mark.parametrize('json', JSONS, ids=[j[2] for j in JSONS])
     def test_json_repos(self, rest_api, json):
         """Tests various json - /repos endpoint."""
-        if json[1] == 'repos':
+        if json[1] in ['repos', 'updates']:
             repos = rest_api.get_repos(body=json[0]).response_check()
+            assert isinstance(repos.raw.body, dict)
             assert 'repository_list' in repos.raw.body
+        elif not json[1]:
+            repos = rest_api.get_repos(body=json[0]).response_check(400)
+            assert not isinstance(repos.raw.body, dict)
+            if json[0]:
+                assert "is not of type 'object'" in repos.raw.body
+            else:
+                assert 'Error: malformed input JSON' in repos.raw.body
         else:
             repos = rest_api.get_repos(body=json[0]).response_check(400)
-            assert 'repository_list' not in repos.raw.body
+            assert not isinstance(repos.raw.body, dict)
+            assert "'repository_list' is a required property" in repos.raw.body


### PR DESCRIPTION
- valid response is JSON (dict), error response is not a dictionary
- check different possible error messages
- `repository_list` is also in `UPDATES_JSON`, so this JSON is considered as valid for `/repos` endpoint (even when it contains unknown properties for this endpoint)